### PR TITLE
fix: bug of float type accuracy and progrees_bar==None

### DIFF
--- a/algorithm.py
+++ b/algorithm.py
@@ -93,7 +93,7 @@ class Calculator:
             while Golds > 0 and NowEffect > NeededEffect:
                 i = upgradePQ.get().name
                 NowGradeI = NowGrade[i]
-                if NowGradeI < 2000:
+                if NowGradeI < 2000 and Golds>=self.Upgrade[Rarities[i]][NowGrade[i] + 1]:
                     Golds -= self.Upgrade[Rarities[i]][NowGrade[i] + 1]
                     NowGrade[i] += 1  # upgrade build
                     upgradePQ.put(NamedPQ(-self.Upgrade['Ratio' + Rarities[i]][NowGrade[i] - 1] * basemultiples[i],

--- a/algorithm.py
+++ b/algorithm.py
@@ -99,13 +99,16 @@ class Calculator:
                     upgradePQ.put(NamedPQ(-self.Upgrade['Ratio' + Rarities[i]][NowGrade[i] - 1] * basemultiples[i],
                                           i))
                     Income += self.Upgrade['incomeIncrease'][NowGrade[i]] * basemultiples[i]
-                    NowEffect = (Income - IncomeUnupgrade) / (self.totalGold - Golds)
+                    if self.totalGold - Golds==0:
+                        NowEffect = 0
+                    else:
+                        NowEffect = (Income - IncomeUnupgrade) / (self.totalGold - Golds)
                     NeededEffect = (MaxIncome - Income) / Golds
                 elif upgradePQ.empty():
                     break
 
         if output:
-            resultFile = open("result.txt", 'w')
+            resultFile = open("result.txt", 'w', encoding='utf-8')
             print('消耗完金币后的最优策略：', file=resultFile)
             print('工业建筑：%s、%s、%s' % (buildings[0]), file=resultFile)
             print('商业建筑：%s、%s、%s' % (buildings[1]), file=resultFile)
@@ -232,7 +235,8 @@ class Calculator:
                     MaxIncome = TotalIncome
                     MaxStat = Stat
                     MaxEffect = NowEffect
-                progress_bar.setValue(progress_bar.value()+1)
+                if progress_bar is not None:
+                    progress_bar.setValue(progress_bar.value()+1)
 
         self.calculateComb(MaxStat[0], output=True)
 


### PR DESCRIPTION
修改两个小问题，在4926489中修正：
1.当前金币太大，升级金币太小，超出浮点精度范围时Effect计算出现被零除
2.外部调用algorithm.calculate()时，传入progress_bar有一处没有判断None
另外，result.txt打开时使用了'utf-8'编码，方便在vscode中查看

新问题，在232f8d7中修正：
calculateComb()中，计算升级使用金币时可能出现金币为负，此时升级方案可能出错。